### PR TITLE
Handle nil cache in ResolveWithOptions

### DIFF
--- a/recursive.go
+++ b/recursive.go
@@ -200,7 +200,8 @@ func (r *Recursive) OrderRoots(ctx context.Context) {
 
 // ResolveWithOptions performs a recursive DNS resolution for the provided name and record type.
 //
-// If cache is nil, no cache is used. If logw is non-nil (or DefaultLogWriter is set), write a log of events.
+// If cache is nil, no cache is used; nil caches are supported without crashing.
+// If logw is non-nil (or DefaultLogWriter is set), write a log of events.
 func (r *Recursive) ResolveWithOptions(ctx context.Context, cache Cacher, logw io.Writer, qname string, qtype uint16) (msg *dns.Msg, srv netip.Addr, err error) {
 	if logw == nil {
 		logw = r.DefaultLogWriter
@@ -245,7 +246,9 @@ func (r *Recursive) ResolveWithOptions(ctx context.Context, cache Cacher, logw i
 			}
 		}
 		if err == nil {
-			cache.DnsSet(msg)
+			if cache != nil {
+				cache.DnsSet(msg)
+			}
 		}
 	}
 	if logw != nil {


### PR DESCRIPTION
## Summary
- avoid panics when ResolveWithOptions is used without a cache
- document that ResolveWithOptions supports nil caches

## Testing
- `go test -run Test_Resolve1111 -count=1 -v` *(fails: command hung or was interrupted)*

------
https://chatgpt.com/codex/tasks/task_b_68bfdf4b6f44832cbe15898d85fbe8ae