### PR TITLE
Prune stale DNS server cookies

### DIFF
--- a/query.go
+++ b/query.go
@@ -466,10 +466,8 @@ func (q *query) exchangeUsing(ctx context.Context, protocol string, useCookies b
 			var clicookie, srvcookie string
 
 			if useCookies {
-				q.mu.RLock()
 				clicookie = q.clicookie
-				srvcookie, hasSrvCookie = q.srvcookies[nsaddr]
-				q.mu.RUnlock()
+				srvcookie, hasSrvCookie = q.getSrvCookie(nsaddr)
 
 				useCookies = !hasSrvCookie || srvcookie != ""
 
@@ -502,9 +500,7 @@ func (q *query) exchangeUsing(ctx context.Context, protocol string, useCookies b
 					}
 				}
 				if !hasSrvCookie || srvcookie != newsrvcookie {
-					q.mu.Lock()
-					q.srvcookies[nsaddr] = newsrvcookie
-					q.mu.Unlock()
+					q.setSrvCookie(nsaddr, newsrvcookie)
 				}
 			}
 		}

--- a/srv_cookie_test.go
+++ b/srv_cookie_test.go
@@ -1,0 +1,25 @@
+package recursive
+
+import (
+	"fmt"
+	"net/netip"
+	"testing"
+	"time"
+)
+
+func TestSrvCookieCleanup(t *testing.T) {
+	r := NewWithOptions(nil, nil, nil, nil, nil)
+	expiredAddr := netip.MustParseAddr("2001:db8::1")
+	r.srvcookies[expiredAddr] = srvCookie{value: "old", ts: time.Now().Add(-srvCookieTTL - time.Minute)}
+	for i := 0; i < maxSrvCookies+10; i++ {
+		addr := netip.MustParseAddr(fmt.Sprintf("2001:db8::%x", i+2))
+		r.srvcookies[addr] = srvCookie{value: "new", ts: time.Now()}
+	}
+	r.cleanupSrvCookies(time.Now())
+	if _, ok := r.srvcookies[expiredAddr]; ok {
+		t.Fatalf("expired cookie was not pruned")
+	}
+	if len(r.srvcookies) > maxSrvCookies {
+		t.Fatalf("expected at most %d cookies, got %d", maxSrvCookies, len(r.srvcookies))
+	}
+}


### PR DESCRIPTION
## Summary
- bound `srvcookies` map with expiration and size limit
- track timestamps and prune old cookies during resolution
- add unit test verifying cookie pruning
- defer unlock in `cleanupSrvCookies`
- use read lock for retrieving cached server cookies
- expand max `srvcookies` to 8192

## Testing
- `go test ./...` *(fails: dial tcp4 199.7.91.13:53: connect: network is unreachable; panic: dial tcp4 192.203.230.10:53: connect: network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68bfe0ad0a68832cb06585ba6adc3035