### PR TITLE
Redact cookies in log output

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,6 @@ func main() {
 }
 
 ```
+
+The resolver can log query details. To protect privacy, logs only include the
+first few characters of the client and server cookie values.

--- a/mask_cookie_test.go
+++ b/mask_cookie_test.go
@@ -1,0 +1,29 @@
+package recursive
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+)
+
+func TestMaskCookie(t *testing.T) {
+	full := "1234567890abcdef"
+	if got := maskCookie(full); got != "12345678..." {
+		t.Errorf("maskCookie(%q) = %q; want %q", full, got, "12345678...")
+	}
+	short := "abcd"
+	if got := maskCookie(short); got != short {
+		t.Errorf("maskCookie(%q) = %q; want %q", short, got, short)
+	}
+}
+
+func TestCookieLogFormat(t *testing.T) {
+	clicookie := "1234567890abcdef"
+	srvcookie := "fedcba0987654321"
+	buf := new(bytes.Buffer)
+	fmt.Fprintf(buf, " COOKIE:c=%q s=%q", maskCookie(clicookie), maskCookie(srvcookie))
+	want := " COOKIE:c=\"12345678...\" s=\"fedcba09...\""
+	if got := buf.String(); got != want {
+		t.Errorf("log output = %q; want %q", got, want)
+	}
+}

--- a/query.go
+++ b/query.go
@@ -42,6 +42,13 @@ func (q *query) log(format string, args ...any) bool {
 	return false
 }
 
+func maskCookie(s string) string {
+	if len(s) > 8 {
+		return s[:8] + "..."
+	}
+	return s
+}
+
 type hostAddr struct {
 	host string
 	addr netip.Addr
@@ -477,7 +484,7 @@ func (q *query) exchangeUsing(ctx context.Context, protocol string, useCookies b
 						Cookie: clicookie + srvcookie,
 					})
 					if q.logw != nil {
-						fmt.Fprintf(q.logw, " COOKIE:%q", clicookie+srvcookie)
+						fmt.Fprintf(q.logw, " COOKIE:c=%q s=%q", maskCookie(clicookie), maskCookie(srvcookie))
 					}
 				}
 			}


### PR DESCRIPTION
## Summary
- redact DNS cookie values before writing them to logs
- log client and server cookie prefixes separately for easier debugging
- document that logs only expose the first few characters of client and server cookie values
- add unit test for cookie redaction helper and log formatting

## Testing
- `go test -run TestMaskCookie -v`
- `go test -run TestCookieLogFormat -v`
- `go test ./...` *(fails: dial tcp4 192.58.128.30:53: connect: network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68bfe4263d6c832c912863bc9ba70b16