### PR TITLE
Skip Test_Resolve1111 when network unavailable

### DIFF
--- a/recursive_test.go
+++ b/recursive_test.go
@@ -12,6 +12,11 @@ import (
 )
 
 func Test_Resolve1111(t *testing.T) {
+	if c, err := net.DialTimeout("tcp", "1.1.1.1:53", time.Second); err != nil {
+		t.Skipf("skipping; network unavailable: %v", err)
+	} else {
+		c.Close()
+	}
 	rec := recursive.New(nil)
 	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
 	defer cancel()


### PR DESCRIPTION
## Summary
- skip the `Test_Resolve1111` test when a TCP dial to 1.1.1.1:53 fails, indicating no network access

## Testing
- `go test -run Test_Resolve1111 -count=1`
- `go test ./...` *(fails: dial tcp4 192.203.230.10:53: connect: network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68bfde701c58832c98efc5948f62d185