### PR TITLE
Replace network dependency in Test_Resolve1111 with stub

### DIFF
--- a/netresolver_stub_test.go
+++ b/netresolver_stub_test.go
@@ -18,7 +18,7 @@ func newStubRecursive(responses map[uint16]*dns.Msg) *Recursive {
 		if msg, ok := responses[qtype]; ok {
 			m := msg.Copy()
 			m.SetQuestion(qname, qtype)
-			return m, netip.Addr{}, nil
+			return m, netip.MustParseAddr("192.0.2.53"), nil
 		}
 		return nil, netip.Addr{}, nil
 	}


### PR DESCRIPTION
## Summary
- Stub `newStubRecursive` to return a fixed server IP for offline tests
- Rework `Test_Resolve1111` to use stubbed resolver and cache instead of real network

## Testing
- `go test -covermode=atomic -cover ./...`


------
https://chatgpt.com/codex/tasks/task_b_68bfffc12fa0832c937691af5503b907