### PR TITLE
Add stub resolver test for one.one.one.one

### DIFF
--- a/recursive_test.go
+++ b/recursive_test.go
@@ -4,26 +4,22 @@ import (
 	"context"
 	"net"
 	"testing"
+	"time"
 
 	"github.com/miekg/dns"
 )
 
 func Test_Resolve1111(t *testing.T) {
 	DefaultCache = NewCache()
-	ipv4 := net.ParseIP("1.1.1.1")
-	aMsg := &dns.Msg{Answer: []dns.RR{&dns.A{
-		Hdr: dns.RR_Header{
-			Name:   "one.one.one.one.",
-			Rrtype: dns.TypeA,
-			Class:  dns.ClassINET,
-			Ttl:    60,
-		},
-		A: ipv4,
-	}}}
-	rec := newStubRecursive(map[uint16]*dns.Msg{dns.TypeA: aMsg})
+	var rec *Recursive
+	if networkAvailable() {
+		rec = New(nil)
+	} else {
+		rec = newStubResolver(stubResponses1111())
+	}
 	ctx := context.Background()
 
-	retv, srv, err := rec.dnsResolve(ctx, "one.one.one.one", dns.TypeA)
+	retv, srv, err := rec.DnsResolve(ctx, "one.one.one.one", dns.TypeA)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -33,6 +29,7 @@ func Test_Resolve1111(t *testing.T) {
 	if len(retv.Answer) == 0 {
 		t.Fatal("no Answer")
 	}
+	ipv4 := net.ParseIP("1.1.1.1")
 	foundit := false
 	for _, rr := range retv.Answer {
 		if a, ok := rr.(*dns.A); ok && a.A.Equal(ipv4) {
@@ -55,7 +52,7 @@ func Test_Resolve1111(t *testing.T) {
 	}
 
 	DefaultCache.DnsSet(retv)
-	msg := DefaultCache.DnsGet("one.one.one.one", dns.TypeA)
+	msg := DefaultCache.DnsGet("one.one.one.one.", dns.TypeA)
 	if msg == nil {
 		t.Fatal("expected cached message")
 	}
@@ -70,4 +67,13 @@ func Test_Resolve1111(t *testing.T) {
 	if hitratio == 0 {
 		t.Error("hit ratio is zero")
 	}
+}
+
+func networkAvailable() bool {
+	c, err := net.DialTimeout("tcp", "198.41.0.4:53", time.Second)
+	if err != nil {
+		return false
+	}
+	c.Close()
+	return true
 }

--- a/stub_resolver_test.go
+++ b/stub_resolver_test.go
@@ -1,0 +1,223 @@
+package recursive
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+type stubKey struct {
+	name  string
+	qtype uint16
+}
+
+type stubDialer struct {
+	responses map[stubKey]*dns.Msg
+}
+
+func (d *stubDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	isTCP := len(network) >= 3 && network[:3] == "tcp"
+	return &stubConn{dialer: d, isTCP: isTCP}, nil
+}
+
+type stubConn struct {
+	dialer *stubDialer
+	isTCP  bool
+	buf    bytes.Buffer
+}
+
+func (c *stubConn) Read(p []byte) (int, error) { return c.buf.Read(p) }
+
+func (c *stubConn) Write(p []byte) (int, error) {
+	origN := len(p)
+	if c.isTCP {
+		if len(p) < 2 {
+			return 0, io.ErrShortWrite
+		}
+		ln := int(binary.BigEndian.Uint16(p[:2]))
+		p = p[2 : 2+ln]
+	}
+	var m dns.Msg
+	if err := m.Unpack(p); err != nil {
+		return 0, err
+	}
+	name := dns.CanonicalName(m.Question[0].Name)
+	qtype := m.Question[0].Qtype
+	key := stubKey{name, qtype}
+	resp, ok := c.dialer.responses[key]
+	if !ok {
+		resp = new(dns.Msg)
+		resp.SetRcode(&m, dns.RcodeServerFailure)
+	} else {
+		resp = resp.Copy()
+		if len(resp.Question) == 0 {
+			resp.SetQuestion(name, qtype)
+		}
+		resp.Id = m.Id
+	}
+	packed, err := resp.Pack()
+	if err != nil {
+		return 0, err
+	}
+	c.buf.Reset()
+	if c.isTCP {
+		var lenbuf [2]byte
+		binary.BigEndian.PutUint16(lenbuf[:], uint16(len(packed)))
+		c.buf.Write(lenbuf[:])
+	}
+	c.buf.Write(packed)
+	return origN, nil
+}
+
+func (c *stubConn) Close() error                       { return nil }
+func (c *stubConn) LocalAddr() net.Addr                { return dummyAddr("local") }
+func (c *stubConn) RemoteAddr() net.Addr               { return dummyAddr("remote") }
+func (c *stubConn) SetDeadline(t time.Time) error      { return nil }
+func (c *stubConn) SetReadDeadline(t time.Time) error  { return nil }
+func (c *stubConn) SetWriteDeadline(t time.Time) error { return nil }
+
+type dummyAddr string
+
+func (d dummyAddr) Network() string { return string(d) }
+func (d dummyAddr) String() string  { return string(d) }
+
+func aRR(name, ip string) dns.RR {
+	return &dns.A{Hdr: dns.RR_Header{Name: dns.Fqdn(name), Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 86400}, A: net.ParseIP(ip)}
+}
+
+func nsRR(name, ns string) dns.RR {
+	return &dns.NS{Hdr: dns.RR_Header{Name: dns.Fqdn(name), Rrtype: dns.TypeNS, Class: dns.ClassINET, Ttl: 86400}, Ns: dns.Fqdn(ns)}
+}
+
+func newStubResolver(resps map[stubKey]*dns.Msg) *Recursive {
+	dialer := &stubDialer{responses: resps}
+	return NewWithOptions(dialer, NewCache(), nil, nil, nil)
+}
+
+func stubResponses1111() map[stubKey]*dns.Msg {
+	responses := map[stubKey]*dns.Msg{}
+	// Root: NS one.
+	responses[stubKey{"one.", dns.TypeNS}] = &dns.Msg{
+		Ns: []dns.RR{
+			nsRR("one.", "a.nic.one."),
+			nsRR("one.", "b.nic.one."),
+			nsRR("one.", "c.nic.one."),
+			nsRR("one.", "x.nic.one."),
+		},
+		Extra: []dns.RR{
+			aRR("a.nic.one.", "37.209.192.9"),
+			aRR("b.nic.one.", "37.209.194.9"),
+			aRR("c.nic.one.", "37.209.196.9"),
+			aRR("x.nic.one.", "156.154.172.82"),
+		},
+	}
+	// a.nic.one.: NS one.one.
+	responses[stubKey{"one.one.", dns.TypeNS}] = &dns.Msg{
+		Ns: []dns.RR{
+			nsRR("one.one.", "auth.g1-dns.one."),
+			nsRR("one.one.", "auth.g1-dns.com."),
+		},
+		Extra: []dns.RR{
+			aRR("auth.g1-dns.one.", "185.10.11.11"),
+		},
+	}
+	// auth.g1-dns.one.: NS one.one.one.
+	responses[stubKey{"one.one.one.", dns.TypeNS}] = &dns.Msg{
+		Ns: []dns.RR{
+			nsRR("one.one.one.", "dorthy.ns.cloudflare.com."),
+			nsRR("one.one.one.", "terin.ns.cloudflare.com."),
+		},
+	}
+	// glue lookups
+	responses[stubKey{"com.", dns.TypeA}] = &dns.Msg{
+		Ns: []dns.RR{
+			nsRR("com.", "a.gtld-servers.net."),
+			nsRR("com.", "b.gtld-servers.net."),
+			nsRR("com.", "c.gtld-servers.net."),
+			nsRR("com.", "d.gtld-servers.net."),
+		},
+		Extra: []dns.RR{
+			aRR("a.gtld-servers.net.", "192.5.6.30"),
+			aRR("b.gtld-servers.net.", "192.33.14.30"),
+			aRR("c.gtld-servers.net.", "192.26.92.30"),
+			aRR("d.gtld-servers.net.", "192.31.80.30"),
+		},
+	}
+	responses[stubKey{"cloudflare.com.", dns.TypeA}] = &dns.Msg{
+		Ns: []dns.RR{
+			nsRR("cloudflare.com.", "ns3.cloudflare.com."),
+			nsRR("cloudflare.com.", "ns4.cloudflare.com."),
+			nsRR("cloudflare.com.", "ns5.cloudflare.com."),
+			nsRR("cloudflare.com.", "ns6.cloudflare.com."),
+		},
+		Extra: []dns.RR{
+			aRR("ns3.cloudflare.com.", "162.159.0.33"),
+			aRR("ns4.cloudflare.com.", "162.159.1.33"),
+			aRR("ns5.cloudflare.com.", "162.159.2.9"),
+			aRR("ns6.cloudflare.com.", "162.159.3.11"),
+		},
+	}
+	responses[stubKey{"ns.cloudflare.com.", dns.TypeA}] = &dns.Msg{
+		Answer: []dns.RR{
+			aRR("ns.cloudflare.com.", "162.159.0.33"),
+			aRR("ns.cloudflare.com.", "162.159.4.8"),
+		},
+	}
+	responses[stubKey{"dorthy.ns.cloudflare.com.", dns.TypeA}] = &dns.Msg{
+		Answer: []dns.RR{
+			aRR("dorthy.ns.cloudflare.com.", "108.162.192.249"),
+			aRR("dorthy.ns.cloudflare.com.", "173.245.58.249"),
+			aRR("dorthy.ns.cloudflare.com.", "172.64.32.249"),
+		},
+	}
+	responses[stubKey{"terin.ns.cloudflare.com.", dns.TypeA}] = &dns.Msg{
+		Answer: []dns.RR{
+			aRR("terin.ns.cloudflare.com.", "108.162.193.236"),
+			aRR("terin.ns.cloudflare.com.", "172.64.33.236"),
+			aRR("terin.ns.cloudflare.com.", "173.245.59.236"),
+		},
+	}
+	// Final NS for one.one.one.one.
+	responses[stubKey{"one.one.one.one.", dns.TypeNS}] = &dns.Msg{
+		Ns: []dns.RR{
+			nsRR("one.one.one.one.", "dorthy.ns.cloudflare.com."),
+			nsRR("one.one.one.one.", "terin.ns.cloudflare.com."),
+		},
+	}
+	// Final A answer
+	finalA := &dns.Msg{
+		Answer: []dns.RR{
+			aRR("one.one.one.one.", "1.1.1.1"),
+			aRR("one.one.one.one.", "1.0.0.1"),
+		},
+	}
+	finalA.Authoritative = true
+	responses[stubKey{"one.one.one.one.", dns.TypeA}] = finalA
+	return responses
+}
+
+func TestStubResolverSimulates1111(t *testing.T) {
+	rec := newStubResolver(stubResponses1111())
+	ctx := context.Background()
+	msg, _, err := rec.DnsResolve(ctx, "one.one.one.one", dns.TypeA)
+	if err != nil {
+		t.Fatalf("DnsResolve error: %v", err)
+	}
+	if msg.Rcode != dns.RcodeSuccess {
+		t.Fatalf("rcode=%v", msg.Rcode)
+	}
+	if len(msg.Answer) != 2 {
+		t.Fatalf("expected 2 answers, got %d", len(msg.Answer))
+	}
+	got1 := msg.Answer[0].(*dns.A).A.String()
+	got2 := msg.Answer[1].(*dns.A).A.String()
+	if (got1 != "1.1.1.1" || got2 != "1.0.0.1") && (got1 != "1.0.0.1" || got2 != "1.1.1.1") {
+		t.Fatalf("unexpected answers: %v %v", got1, got2)
+	}
+}


### PR DESCRIPTION
## Summary
- add stub dialer/connection to simulate DNS resolution without network
- add test covering recursive resolution path for one.one.one.one
- use stub resolver for `Test_Resolve1111` only when network is unavailable
- simplify stub resolver setup by relying on default root hints

## Testing
- `go test -cover ./...`


------
https://chatgpt.com/codex/tasks/task_b_68c007a25804832cbb501ab86ce011a5