### PR TITLE
Refactor cache TTLs and dedupe LookupIP

### DIFF
--- a/cache_test.go
+++ b/cache_test.go
@@ -3,6 +3,7 @@ package recursive
 import (
 	"net"
 	"testing"
+	"time"
 
 	"github.com/miekg/dns"
 )
@@ -19,7 +20,7 @@ func newTestMsg(name string, ttl uint32) *dns.Msg {
 func TestCacheSetGetAndStats(t *testing.T) {
 	c := NewCache()
 	c.MinTTL = 0
-	c.MaxTTL = 60
+	c.MaxTTL = 60 * time.Second
 	msg := newTestMsg("example.org.", 5)
 	c.DnsSet(msg)
 	if entries := c.Entries(); entries != 1 {
@@ -43,7 +44,7 @@ func TestCacheSetGetAndStats(t *testing.T) {
 func TestCacheClean(t *testing.T) {
 	c := NewCache()
 	c.MinTTL = 0
-	c.MaxTTL = -1
+	c.MaxTTL = -1 * time.Second
 	msg := new(dns.Msg)
 	msg.SetQuestion("example.org.", dns.TypeA)
 	c.DnsSet(msg)

--- a/exchange_test.go
+++ b/exchange_test.go
@@ -1,0 +1,18 @@
+package recursive
+
+import (
+	"context"
+	"errors"
+	"net/netip"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+func TestExchangeUsingMaxSteps(t *testing.T) {
+	q := &query{Recursive: &Recursive{}}
+	q.steps = maxSteps
+	if _, err := q.exchangeUsing(context.Background(), "udp", false, netip.MustParseAddr("192.0.2.1"), "example.org.", dns.TypeA); !errors.Is(err, ErrMaxSteps) {
+		t.Fatalf("expected ErrMaxSteps, got %v", err)
+	}
+}

--- a/neterror_test.go
+++ b/neterror_test.go
@@ -1,0 +1,113 @@
+package recursive
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/netip"
+	"syscall"
+	"testing"
+)
+
+func TestSetNetErrorRecords(t *testing.T) {
+	r := &Recursive{udperrs: make(map[netip.Addr]netError), tcperrs: make(map[netip.Addr]netError)}
+
+	addr6 := netip.MustParseAddr("2001:db8::1")
+	is6, isUdp := r.setNetError("udp", addr6, io.EOF)
+	if !is6 || !isUdp {
+		t.Fatalf("unexpected flags: ipv6=%v udp=%v", is6, isUdp)
+	}
+	if _, ok := r.udperrs[addr6]; !ok {
+		t.Fatalf("expected udp error recorded for %v", addr6)
+	}
+
+	addr4 := netip.MustParseAddr("192.0.2.1")
+	is6, isUdp = r.setNetError("tcp", addr4, context.DeadlineExceeded)
+	if is6 || isUdp {
+		t.Fatalf("unexpected flags for tcp ipv4: ipv6=%v udp=%v", is6, isUdp)
+	}
+	if _, ok := r.tcperrs[addr4]; !ok {
+		t.Fatalf("expected tcp error recorded for %v", addr4)
+	}
+
+	addrTimeout := netip.MustParseAddr("192.0.2.2")
+	is6, isUdp = r.setNetError("udp", addrTimeout, errors.New("i/o timeout"))
+	if is6 || !isUdp {
+		t.Fatalf("unexpected flags for timeout: ipv6=%v udp=%v", is6, isUdp)
+	}
+	if _, ok := r.udperrs[addrTimeout]; !ok {
+		t.Fatalf("expected udp timeout recorded for %v", addrTimeout)
+	}
+}
+
+type timeoutErr struct{}
+
+func (timeoutErr) Error() string   { return "timeout" }
+func (timeoutErr) Timeout() bool   { return true }
+func (timeoutErr) Temporary() bool { return true }
+
+func TestMaybeDisableIPv6(t *testing.T) {
+	ip4 := netip.MustParseAddr("192.0.2.1")
+	ip6 := netip.MustParseAddr("2001:db8::1")
+	r := &Recursive{useIPv4: true, useIPv6: true, rootServers: []netip.Addr{ip4, ip6}}
+
+	if !r.maybeDisableIPv6(syscall.ENETUNREACH) {
+		t.Fatalf("expected IPv6 to be disabled")
+	}
+	if r.useIPv6 {
+		t.Fatalf("IPv6 still enabled")
+	}
+	if len(r.rootServers) != 1 || r.rootServers[0] != ip4 {
+		t.Fatalf("IPv6 root not removed: %v", r.rootServers)
+	}
+}
+
+func TestMaybeDisableIPv6String(t *testing.T) {
+	ip4 := netip.MustParseAddr("192.0.2.1")
+	ip6 := netip.MustParseAddr("2001:db8::1")
+	r := &Recursive{useIPv4: true, useIPv6: true, rootServers: []netip.Addr{ip4, ip6}}
+
+	if !r.maybeDisableIPv6(errors.New("no route to host")) {
+		t.Fatalf("expected IPv6 to be disabled on string error")
+	}
+	if r.useIPv6 {
+		t.Fatalf("IPv6 still enabled")
+	}
+	if len(r.rootServers) != 1 || r.rootServers[0] != ip4 {
+		t.Fatalf("IPv6 root not removed: %v", r.rootServers)
+	}
+}
+
+func TestMaybeDisableUdp(t *testing.T) {
+	r := &Recursive{useUDP: true}
+	err := &net.OpError{Op: "dial", Net: "udp", Err: syscall.ENOSYS}
+	if !r.maybeDisableUdp(err) {
+		t.Fatalf("expected UDP to be disabled")
+	}
+	if r.useUDP {
+		t.Fatalf("UDP still enabled")
+	}
+}
+
+func TestMaybeDisableUdpString(t *testing.T) {
+	r := &Recursive{useUDP: true}
+	err := &net.OpError{Op: "dial", Net: "udp", Err: errors.New("network not implemented")}
+	if !r.maybeDisableUdp(err) {
+		t.Fatalf("expected UDP to be disabled on string error")
+	}
+	if r.useUDP {
+		t.Fatalf("UDP still enabled")
+	}
+}
+
+func TestMaybeDisableUdpTimeout(t *testing.T) {
+	r := &Recursive{useUDP: true}
+	err := &net.OpError{Op: "dial", Net: "udp", Err: timeoutErr{}}
+	if r.maybeDisableUdp(err) {
+		t.Fatalf("UDP disabled on timeout error")
+	}
+	if !r.useUDP {
+		t.Fatalf("UDP unexpectedly disabled")
+	}
+}

--- a/netresolver_stub_test.go
+++ b/netresolver_stub_test.go
@@ -29,8 +29,13 @@ func TestLookupFunctionsWithStub(t *testing.T) {
 	ipv4 := net.ParseIP("192.0.2.1")
 	ipv6 := net.ParseIP("2001:db8::1")
 
-	aMsg := &dns.Msg{Answer: []dns.RR{&dns.A{Hdr: dns.RR_Header{Name: "example.org.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 60}, A: ipv4}}}
-	aaaaMsg := &dns.Msg{Answer: []dns.RR{&dns.AAAA{Hdr: dns.RR_Header{Name: "example.org.", Rrtype: dns.TypeAAAA, Class: dns.ClassINET, Ttl: 60}, AAAA: ipv6}}}
+	aMsg := &dns.Msg{Answer: []dns.RR{
+		&dns.A{Hdr: dns.RR_Header{Name: "example.org.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 60}, A: ipv4},
+		&dns.A{Hdr: dns.RR_Header{Name: "example.org.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 60}, A: ipv4},
+	}}
+	aaaaMsg := &dns.Msg{Answer: []dns.RR{
+		&dns.AAAA{Hdr: dns.RR_Header{Name: "example.org.", Rrtype: dns.TypeAAAA, Class: dns.ClassINET, Ttl: 60}, AAAA: ipv6},
+	}}
 	nsMsg := &dns.Msg{Answer: []dns.RR{&dns.NS{Hdr: dns.RR_Header{Name: "example.org.", Rrtype: dns.TypeNS, Class: dns.ClassINET, Ttl: 60}, Ns: "ns.example.org."}}}
 
 	r := newStubRecursive(map[uint16]*dns.Msg{
@@ -50,6 +55,9 @@ func TestLookupFunctionsWithStub(t *testing.T) {
 	}
 	if !ips[0].Equal(ipv6) && !ips[1].Equal(ipv6) {
 		t.Errorf("IPv6 address missing from LookupIP")
+	}
+	if ips[0].Equal(ips[1]) {
+		t.Errorf("duplicate IPs returned from LookupIP")
 	}
 
 	ips4, err := r.LookupIP(ctx, "ip4", "example.org")

--- a/query.go
+++ b/query.go
@@ -400,7 +400,7 @@ func (q *query) followCNAME(cn string) bool {
 func (q *query) exchangeUsing(ctx context.Context, protocol string, useCookies bool, nsaddr netip.Addr, qname string, qtype uint16) (msg *dns.Msg, err error) {
 	q.steps++
 	if q.steps > maxSteps {
-		err = ErrMaxDepth
+		err = ErrMaxSteps
 		return
 	}
 	if q.cache != nil && !q.nomini {


### PR DESCRIPTION
## Summary
- represent cache TTL settings with time.Duration
- deduplicate IP results in LookupIP and related helpers
- track network errors with typed errors and add max step error
- test exchange step limit, deduplication, and network error handling
- add string fallbacks for network error detection

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68c010eb6800832cb0b12ecbefe6f3cd