### PR TITLE
test: add TTL expiration eviction test

### DIFF
--- a/cache_test.go
+++ b/cache_test.go
@@ -56,3 +56,20 @@ func TestCacheClean(t *testing.T) {
 		t.Fatalf("Entries() after Clean = %d; want 0", entries)
 	}
 }
+
+func TestCacheTTLExpiration(t *testing.T) {
+	c := NewCache()
+	c.MinTTL = 0
+	c.MaxTTL = 60 * time.Second
+	msg := newTestMsg("example.org.", 0)
+	c.DnsSet(msg)
+	if entries := c.Entries(); entries != 1 {
+		t.Fatalf("Entries() before expiration = %d; want 1", entries)
+	}
+	if got := c.DnsGet("example.org.", dns.TypeA); got != nil {
+		t.Fatalf("DnsGet after expiration returned %v; want nil", got)
+	}
+	if entries := c.Entries(); entries != 0 {
+		t.Fatalf("Entries() after expiration = %d; want 0", entries)
+	}
+}


### PR DESCRIPTION
## Summary
- add unit test verifying cache entries are evicted after TTL expiration using a zero TTL (no sleep)

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68c12812ac70832c8e2c2ad4b765343c