### PR TITLE
Make DNS port configurable per resolver

### DIFF
--- a/dnsport.go
+++ b/dnsport.go
@@ -1,3 +1,0 @@
-package recursive
-
-var dnsPort uint16 = 53

--- a/err_question_mismatch_test.go
+++ b/err_question_mismatch_test.go
@@ -30,11 +30,8 @@ func TestResolveWithOptionsErrQuestionMismatch(t *testing.T) {
 	t.Cleanup(func() { _ = srv.Shutdown() })
 
 	port := udpConn.LocalAddr().(*net.UDPAddr).Port
-	oldPort := dnsPort
-	dnsPort = uint16(port)
-	defer func() { dnsPort = oldPort }()
-
 	r := NewWithOptions(nil, nil, []netip.Addr{netip.MustParseAddr("127.0.0.1")}, nil, nil)
+	r.DNSPort = uint16(port)
 	_, _, err = r.ResolveWithOptions(context.Background(), nil, nil, "example.org.", dns.TypeA)
 	if !errors.Is(err, ErrQuestionMismatch) {
 		t.Fatalf("err = %v; want ErrQuestionMismatch", err)

--- a/new_reset_orderroots_test.go
+++ b/new_reset_orderroots_test.go
@@ -46,9 +46,9 @@ func TestNewCallsOrderRoots(t *testing.T) {
 	fail := netip.MustParseAddr("192.0.2.3")
 
 	d := &fakeDialer{delays: map[string]time.Duration{
-		netip.AddrPortFrom(fast, dnsPort).String(): 5 * time.Millisecond,
-		netip.AddrPortFrom(slow, dnsPort).String(): 25 * time.Millisecond,
-		netip.AddrPortFrom(fail, dnsPort).String(): -1,
+		netip.AddrPortFrom(fast, DefaultDNSPort).String(): 5 * time.Millisecond,
+		netip.AddrPortFrom(slow, DefaultDNSPort).String(): 25 * time.Millisecond,
+		netip.AddrPortFrom(fail, DefaultDNSPort).String(): -1,
 	}}
 
 	old4, old6 := Roots4, Roots6
@@ -74,10 +74,10 @@ func TestOrderRoots(t *testing.T) {
 	fail6 := netip.MustParseAddr("2001:db8::2")
 
 	d := &fakeDialer{delays: map[string]time.Duration{
-		netip.AddrPortFrom(fast4, dnsPort).String(): 5 * time.Millisecond,
-		netip.AddrPortFrom(fast6, dnsPort).String(): 15 * time.Millisecond,
-		netip.AddrPortFrom(fail4, dnsPort).String(): -1,
-		netip.AddrPortFrom(fail6, dnsPort).String(): -1,
+		netip.AddrPortFrom(fast4, DefaultDNSPort).String(): 5 * time.Millisecond,
+		netip.AddrPortFrom(fast6, DefaultDNSPort).String(): 15 * time.Millisecond,
+		netip.AddrPortFrom(fail4, DefaultDNSPort).String(): -1,
+		netip.AddrPortFrom(fail6, DefaultDNSPort).String(): -1,
 	}}
 
 	r := NewWithOptions(d, nil, []netip.Addr{fast4, fail4}, []netip.Addr{fast6, fail6}, nil)

--- a/query.go
+++ b/query.go
@@ -482,7 +482,7 @@ func (q *query) exchangeUsing(ctx context.Context, protocol string, useCookies b
 			ctx = ctx2
 		}
 
-		if nconn, err = q.DialContext(ctx, network, netip.AddrPortFrom(nsaddr, dnsPort).String()); err == nil {
+		if nconn, err = q.DialContext(ctx, network, netip.AddrPortFrom(nsaddr, q.DNSPort).String()); err == nil {
 			q.sent++
 			dnsconn := &dns.Conn{Conn: nconn, UDPSize: dns.DefaultMsgSize}
 			defer dnsconn.Close()

--- a/recursive.go
+++ b/recursive.go
@@ -38,9 +38,10 @@ var (
 	// It is equivalent to SERVFAIL.
 	ErrNoResponse = errors.New("no authoritative response")
 	// ErrQuestionMismatch is returned when the DNS response is not for what was queried.
-	ErrQuestionMismatch = errors.New("question mismatch")
-	DefaultCache        = NewCache()
-	DefaultTimeout      = time.Second * 5
+	ErrQuestionMismatch        = errors.New("question mismatch")
+	DefaultCache               = NewCache()
+	DefaultTimeout             = time.Second * 5
+	DefaultDNSPort      uint16 = 53
 )
 
 var _ Resolver = (*Recursive)(nil) // ensure we implement interface
@@ -59,6 +60,7 @@ type Recursive struct {
 	proxy.ContextDialer                 // (read-only) ContextDialer passed to NewWithOptions
 	Cacher                              // (read-only) Cacher passed to NewWithOptions
 	*net.Resolver                       // (read-only) net.Resolver using our ContextDialer
+	DNSPort             uint16          // port used for DNS queries
 	Timeout             time.Duration   // (read-only) dialing timeout, zero to disable
 	rateLimiter         <-chan struct{} // (read-only) rate limited passed to NewWithOptions
 	DefaultLogWriter    io.Writer       // if not nil, write debug logs here unless overridden
@@ -131,6 +133,7 @@ func NewWithOptions(dialer proxy.ContextDialer, cache Cacher, roots4, roots6 []n
 			PreferGo: true,
 			Dial:     dialer.DialContext,
 		},
+		DNSPort:     DefaultDNSPort,
 		Timeout:     DefaultTimeout,
 		rateLimiter: rateLimiter,
 		useUDP:      true,

--- a/resolve_test.go
+++ b/resolve_test.go
@@ -61,9 +61,6 @@ func Test_Resolve1111(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parse port: %v", err)
 	}
-	oldPort := dnsPort
-	dnsPort = uint16(p)
-	defer func() { dnsPort = oldPort }()
 
 	for _, ip := range addrs[1:] {
 		srv, err := dnstest.NewServer(net.JoinHostPort(ip, portStr), dnstestResps)
@@ -80,6 +77,7 @@ func Test_Resolve1111(t *testing.T) {
 
 	roots := []netip.Addr{netip.MustParseAddr(addrs[0])}
 	rec := NewWithOptions(nil, NewCache(), roots, nil, nil)
+	rec.DNSPort = uint16(p)
 	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
 	defer cancel()
 	var logw strings.Builder

--- a/timeroot.go
+++ b/timeroot.go
@@ -5,8 +5,6 @@ import (
 	"net/netip"
 	"sync"
 	"time"
-
-	"golang.org/x/net/proxy"
 )
 
 type rootRtt struct {
@@ -14,7 +12,7 @@ type rootRtt struct {
 	rtt  time.Duration
 }
 
-func timeRoot(ctx context.Context, dialer proxy.ContextDialer, wg *sync.WaitGroup, rt *rootRtt) {
+func timeRoot(ctx context.Context, r *Recursive, wg *sync.WaitGroup, rt *rootRtt) {
 	defer wg.Done()
 	const numProbes = 3
 	network := "tcp4"
@@ -25,7 +23,7 @@ func timeRoot(ctx context.Context, dialer proxy.ContextDialer, wg *sync.WaitGrou
 	var rtt time.Duration
 	for i := 0; i < numProbes; i++ {
 		now := time.Now()
-		conn, err := dialer.DialContext(ctx, network, netip.AddrPortFrom(rt.addr, dnsPort).String())
+		conn, err := r.DialContext(ctx, network, netip.AddrPortFrom(rt.addr, r.DNSPort).String())
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
## Summary
- move package-level dnsPort into public Recursive.DNSPort field
- default DNS port set via DefaultDNSPort
- use per-resolver DNSPort in query and root timing logic

## Testing
- `go generate ./...` *(fails: Get "https://www.internic.net/domain/named.root": Forbidden)*
- `go test -cover ./...` *(fails: Get "https://proxy.golang.org/github.com/linkdata/dnstest/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68c3da6d9d78832cbb9ed1691475a3da